### PR TITLE
Fixed the typo in the documentation of the private variable `variables` of the RemoteController class

### DIFF
--- a/src/RemoteController.tsx
+++ b/src/RemoteController.tsx
@@ -56,7 +56,7 @@ class RemoteController {
   /**
    * The array of remixer variables.
    * @private
-   * @type {Variable[]]}
+   * @type {Variable[]}
    */
   private variables: Variable[] = [];
 


### PR DESCRIPTION
The typo occurred when specifying the type of the `variables` variable. It was supposed to be `Variable[]` but instead it was `Variable[]]`.

The typo is in [RemoteController.tsx](https://github.com/material-foundation/material-remixer-remote-web/blob/develop/src/RemoteController.tsx) on line#59.

```typescript
 /**
   * The array of remixer variables.
   * @private
   * @type {Variable[]]}       <---- typo!
   */
  private variables: Variable[] = [];
```

PR corresponds the [issue#12](https://github.com/material-foundation/material-remixer-remote-web/issues/12)

`-Sid`